### PR TITLE
Add install options to "Getting Started" section of docs

### DIFF
--- a/source/documentation/4.0/index.markdown
+++ b/source/documentation/4.0/index.markdown
@@ -31,13 +31,27 @@ The FW/1 software family is copyright (c) 2009-2015 Sean Corfield (and others). 
 
 The FW/1 documentation is copyright (c) 2009-2015 Sean Corfield and is made available under [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
-## Your First FW/1 Application
+## Installing FW/1
 
-FW/1 itself consists of a single CFC: `framework.one`, i.e., `framework/one.cfc`. Your `Application.cfc` will extend that and your application's "pages" will live under a `views` folder inside a subfolder for each _section_ of your application.
+There are two options from which to install FW/1.
+
+**Download from Github or RIAForge**
+
+FW/1 can be downloaded directly from [Github](https://github.com/framework-one/fw1) or [RIAForge](http://fw1.riaforge.org/).
 
 When you download FW/1 (or check it out from Github), it's a complete web application. **The `framework` folder should either be copied to your webroot (the simplest way to get started) or else made accessible via a mapping for `/framework`.** Since `Application.cfc` extends `framework.one`, you have to add that mapping in your CFML admin - you cannot use a per-application mapping. _In release 3.5 there is a way to avoid the mapping and extending `framework.one` which we'll cover in the [Developing Applications Guide](developing-applications.html#alternative-application-structure)._
 
+**Download with CommandBox**
+
+FW/1 may also be installed via [CommandBox](https://www.ortussolutions.com/products/commandbox). From your command prompt, you can easily install FW/1 by entering `box install fw1` and the latest stable version will be installed to your current working directory. To install the latest development vesion of FW/1, simply enter `box install fw1-dev`. Refer to the [CommandBox documentation](https://ortus.gitbooks.io/commandbox-documentation/content/setup/installation.html) for more info on installing and using CommandBox.
+
+_This is a minimal install and only the `framework` folder is installed via this method_. To start with a complete working application, you can grab the `examples` folder from the full Github/RIAForge download (see the first install method) or generate one via [FW/1 Commands](https://github.com/framework-one/fw1-commands) from CommandBox.
+
 _**Note: do not install FW/1 into a subfolder that contains . in the name as this may prevent CFC resolution from working!**_
+
+## Your First FW/1 Application
+
+FW/1 itself consists of a single CFC: `framework.one`, i.e., `framework/one.cfc`. Your `Application.cfc` will extend that and your application's "pages" will live under a `views` folder inside a subfolder for each _section_ of your application.
 
 The simplest FW/1 application comprises:
 


### PR DESCRIPTION
Added "Installing FW/1" section in the "Getting Started" portion of the 4.0 docs to reflect options for installing the framework via Github/RIAForge and CommandBox.

This ties to: https://github.com/framework-one/fw1/issues/425